### PR TITLE
Make madeira-port work with ASDF 3.3

### DIFF
--- a/madeira-port.asd
+++ b/madeira-port.asd
@@ -23,16 +23,12 @@
   :description
   "Provides :MADEIRA-PORT file class for ASDF, and an extended #+ and #- syntax."
   :author "Nikodemus Siivola <nikodemus@random-state.net>"
-  :components
-  ((:file "madeira-port")))
+  :components ((:file "madeira-port"))
+  :in-order-to ((test-op (test-op "madeira-port/tests"))))
 
-(defsystem :madeira-port-tests
+(defsystem :madeira-port/tests
   :licence "MIT"
   :description "Tests for MADEIRA-PORT."
   :depends-on (:madeira-port :eos)
-  :components
-  ((:file "tests")))
-
-(defmethod perform ((op test-op) (sys (eql (find-system :madeira-port))))
-  (load-system :madeira-port-tests :force '(:madeira-port-tests))
-  (funcall (intern "RUN-TESTS" :madeira-port-tests)))
+  :components ((:file "tests"))
+  :perform (test-op (o c) (symbol-call :madeira-port-tests :run-tests)))

--- a/madeira-port.lisp
+++ b/madeira-port.lisp
@@ -267,17 +267,24 @@ options evaluate to true under FEATURE-EVAL."))
   (or (slot-value port 'test)
       (warn "~S has no feature conditionals." port)))
 
-(defmethod perform :around ((op load-op) (port madeira-port))
+
+(defmethod input-files :around ((op operation) (port madeira-port))
   (when (feature-eval (test-expr port))
     (call-next-method)))
 
-(defmethod perform :around ((op load-source-op) (port madeira-port))
+(defmethod output-files :around ((op operation) (port madeira-port))
   (when (feature-eval (test-expr port))
     (call-next-method)))
 
-(defmethod perform :around ((op compile-op) (port madeira-port))
+(defmethod component-depends-on :around ((op operation) (port madeira-port))
   (when (feature-eval (test-expr port))
     (call-next-method)))
+
+(defmethod perform :around ((op operation) (port madeira-port))
+  (if (feature-eval (test-expr port))
+      (call-next-method)
+      (asdf::mark-operation-done op port)))
+
 
 ;;; Switch package to circumvent package locks on implementations supporting
 ;;; them -- not that ASDF currently locked, but it might be in the future.


### PR DESCRIPTION
Define proper input-files, output-files, component-depends-on, perform methods.

PS: Isn't madeira-port largely redundant with ASDF 3.0's :if-feature feature?